### PR TITLE
Fix query selectors for qt webengine

### DIFF
--- a/is-land.js
+++ b/is-land.js
@@ -11,7 +11,7 @@ class Island extends HTMLElement {
   static onReady = new Map();
 
   static fallback = {
-    ":not(is-land,:defined,[defer-hydration])": (readyPromise, node, prefix) => {
+    "*:not(is-land):not(:defined):not([defer-hydration])": (readyPromise, node, prefix) => {
       // remove from document to prevent web component init
       let cloned = document.createElement(prefix + node.localName);
       for(let attr of node.getAttributeNames()) {
@@ -21,7 +21,7 @@ class Island extends HTMLElement {
       // Declarative Shadow DOM (with polyfill)
       let shadowroot = node.shadowRoot;
       if(!shadowroot) {
-        let tmpl = node.querySelector(":scope > template:is([shadowrootmode], [shadowroot])");
+        let tmpl = node.querySelector(":scope > template[shadowrootmode], template[shadowroot]");
         if(tmpl) {
           let mode = tmpl.getAttribute("shadowrootmode") || tmpl.getAttribute("shadowroot") || "closed";
           shadowroot = node.attachShadow({ mode }); // default is closed

--- a/is-land.js
+++ b/is-land.js
@@ -11,7 +11,7 @@ class Island extends HTMLElement {
   static onReady = new Map();
 
   static fallback = {
-    "*:not(is-land):not(:defined):not([defer-hydration])": (readyPromise, node, prefix) => {
+    ":not(is-land):not(:defined):not([defer-hydration])": (readyPromise, node, prefix) => {
       // remove from document to prevent web component init
       let cloned = document.createElement(prefix + node.localName);
       for(let attr of node.getAttributeNames()) {
@@ -21,7 +21,7 @@ class Island extends HTMLElement {
       // Declarative Shadow DOM (with polyfill)
       let shadowroot = node.shadowRoot;
       if(!shadowroot) {
-        let tmpl = node.querySelector(":scope > template[shadowrootmode], template[shadowroot]");
+        let tmpl = node.querySelector(":scope > template[shadowrootmode], :scope > template[shadowroot]");
         if(tmpl) {
           let mode = tmpl.getAttribute("shadowrootmode") || tmpl.getAttribute("shadowroot") || "closed";
           shadowroot = node.attachShadow({ mode }); // default is closed


### PR DESCRIPTION
![image](https://github.com/11ty/is-land/assets/6105977/91cec68b-6e53-4fac-9463-933db493561a)
![image](https://github.com/11ty/is-land/assets/6105977/a8984323-0491-4ab6-babd-9da72bf232d7)
I'm using the qutebrowser browser, which in turn uses the qt webengine and does not support some selectors in the same way as chrome and other browsers.