### PR TITLE
Adding SolidJS web component examples

### DIFF
--- a/demo/demo-solid.html
+++ b/demo/demo-solid.html
@@ -1,0 +1,57 @@
+---
+layout: layout.html
+title: SolidJS Islands
+---
+<h1><a href="/">is-land</a> using <img src="https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Fsolidjs.com%2F/" alt="IndieWeb avatar for https://solidjs.com/" width="28" height="28" decoding="async" loading="lazy">SolidJS</h1>
+
+<h2>Scroll down</h2>
+
+<hr style="height: 100vh">
+
+<h2>Client-rendered SolidJS</h2>
+
+<p>Example from <a href="https://www.solidjs.com/guides/getting-started#buildless-options"><code>https://www.solidjs.com/guides/getting-started#buildless-options</code></a></p>
+
+<h2>Client-rendered SolidJS</h2>
+
+<p>You can use `import="./solid-component.js"` or `&lt;template data-island&gt; with &lt;script type="module"&gt;`:</p>
+
+<is-land on:visible import="./lib/solid/solid-component-client.js">
+	This is a solid component:
+	<solid-component-client class="demo-component" name="SolidJS">Fallback content!</solid-web-component>
+</is-land>
+
+<is-land on:visible id="solid-test">
+	This is a solid component: <solid-other-web-component class="demo-component" name="SolidJS">Fallback content!</solid-other-web-component>
+
+	<template data-island>
+		<script type="module">
+		import { createSignal } from "https://esm.sh/solid-js@1.8.16";
+		import html from "https://esm.sh/solid-js@1.8.16/html";
+		import { customElement } from "https://esm.sh/solid-element@1.8.0";
+
+		customElement('solid-other-web-component', { name: undefined },
+
+		  (props, { element }) => {
+			element.classList.add("test-c-finish");
+			const [count, setCount] = createSignal(0);
+			return html`
+		<style>
+		p { color: blue; margin: 0 }
+		</style>
+		<p>Hello, ${() => props.name || "Stranger"}!</p>
+		<div>
+		<button onclick=${() => setCount(count() + 1)} >Increment</button>
+		Counter: ${count}
+		</div>
+		`;
+		  });
+		</script>
+	</template>
+</is-land>
+
+
+<h2>Server-rendered SolidJS (SSR)</h2>
+<p>
+	Hitting error "does not provide an export named 'Aliases'" when trying to use SSR with this current setup. See <a href="https://github.com/solidjs/solid/issues/1984">https://github.com/solidjs/solid/issues/1984</a>
+</p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -45,6 +45,7 @@ title: Islands
 	<li><a href="demo-preact.html"><img src="https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Fpreactjs.com%2F/" alt="IndieWeb avatar for https://preactjs.com/" width="28" height="28" decoding="async" loading="lazy">Preact</a> (and SSR)</li>
 	<li><a href="demo-lit.html"><img src="https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Flit.dev%2F/" alt="IndieWeb avatar for https://lit.dev/" width="28" height="28" decoding="async" loading="lazy">Lit</a> (and SSR)</li>
 	<li><a href="demo-alpine.html"><img src="https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Falpinejs.dev%2F/" alt="IndieWeb avatar for https://alpinejs.dev/" width="28" height="28" decoding="async" loading="lazy">Alpine.js</a></li>
+	<li><a href="demo-solid.html"><img src="https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Fsolidjs.com%2F/" alt="IndieWeb avatar for https://solidjs.com/" width="28" height="28" decoding="async" loading="lazy">Solid</a></li>
 	<li><a href="demo-markdown.html">Embedded in <img src="https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Fwww.markdownguide.org%2F/" alt="IndieWeb avatar for https://www.markdownguide.org/" width="28" height="28" decoding="async" loading="lazy">Markdown</a></li>
 	<li><a href="demo-defer-hydration.html"><code>defer-hydration</code> Component Attribute Support</a> <em>(New in v3.0.0)</em> <a href="https://www.zachleat.com/web/defer-hydration/">Read more about `defer-hydration` at zachleat.com</a></li>
 	<li><em>Experimental:</em> <a href="demo-image-loading.html">Image Loading</a></li>

--- a/lib/solid/solid-component-client.js
+++ b/lib/solid/solid-component-client.js
@@ -1,0 +1,25 @@
+import {createSignal} from "https://esm.sh/solid-js@1.8.16";
+import html from "https://esm.sh/solid-js@1.8.16/html";
+import { customElement } from "https://esm.sh/solid-element@1.8.0";
+
+customElement('solid-component-client', { name: undefined },
+
+  /**
+    * @param {{name: string | undefined}} props
+    * @param {{element: HTMLElement}} input
+    */
+  (props, { element }) => {
+    element.classList.add("test-c-finish");
+    const [count, setCount] = createSignal(0);
+    return html`
+<style>
+p { color: blue; margin: 0 }
+</style>
+<p>Hello, ${() => props.name || "Stranger"}!</p>
+<div>
+<button onclick=${() => setCount(count() + 1)} >Increment</button>
+Counter: ${count}
+</div>
+`;
+  });
+


### PR DESCRIPTION
These are basic examples utilizing `solid-element` web components as trying to implement the SSR examples similar to Preact resulted in the error `does not provide an export named 'Aliases'` which is discussed in https://github.com/solidjs/solid/issues/1984