### PR TITLE
Add Rails + Svelte integration with actionview-svelte-handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Integrations in the wild:
 * [SvelteKit](https://twitter.com/geoffrich_/status/1576932300960342018)
 * [Bridgetown](https://twitter.com/jaredcwhite/status/1585433466770173953)
 * [Lit](https://twitter.com/techytacos/status/1590248099297259520)
+* [Rails & Svelte](https://codeberg.org/reesericci/actionview-svelte-handler)
 
 ## Installation
 


### PR DESCRIPTION
My project, `actionview-svelte-handler` renders the Svelte component by default with is-land, so it can be implemented in parts of a Rails app that needs more client-side interactivity!